### PR TITLE
move alignment override

### DIFF
--- a/Core/Src/command_station.cpp
+++ b/Core/Src/command_station.cpp
@@ -58,9 +58,6 @@ void CommandStationThread(void *argument) {
   __HAL_TIM_ENABLE_IT(&htim2, TIM_IT_UPDATE);
   HAL_TIM_PWM_Start_IT(&htim2, TIM_CHANNEL_1);
 
-#if defined(DEBUG)
-  SCB->CCR &= ~SCB_CCR_UNALIGN_TRP_Msk;
-#endif
   // Main loop
   // Send a few packets to test the command station
   // This is not part of the command station functionality, but rather a test

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -114,6 +114,9 @@ int main(void)
 
   /* USER CODE BEGIN 1 */
 
+  // Override alignment issue with DCC library on M33
+  SCB->CCR &= ~SCB_CCR_UNALIGN_TRP_Msk;
+
   /* USER CODE END 1 */
 
   /* MCU Configuration--------------------------------------------------------*/


### PR DESCRIPTION
DCC library causes an alignment hard fault on M33 processor.
Structs need to be 32bit aligned.
This overrides the fault at the expense of performance.
DCC library needs to apply align attribute to structs. 